### PR TITLE
Derive InfluxDB database and measurement from dev_id and signal data from all gateways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .venv*
 /dist
 /var
+/build

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Command line arguments
 ----------------------
 ::
 
-    ttnlogger -i "<ttn_app_id>" -k "<ttn_access_key>" [-s] [-d <influxdb_database>] [-m <influxdb_measurement>]
+    ttnlogger -i "<ttn_app_id>" -k "<ttn_access_key>" [-s] [-d "<influxdb_database>"] [-m "<influxdb_measurement>"]
 
 
 Environment variables

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,8 @@ In case of using it within the Hiveeyes.org environment please follow this schem
 
 and replace upper case strings with your individual lower case namings without additional dashes)
 
+The ``-n`` option disables saving geolocations of receiving gateways into the database.
+
 Command line arguments
 ----------------------
 ::

--- a/README.rst
+++ b/README.rst
@@ -14,16 +14,23 @@ TTN (`The Things Network`_) is building a global open LoRaWAN™ network.
 ********
 Synopsis
 ********
-The ``ttnlogger`` program can be invoked in two ways. Either it obtains four
-positional arguments on the command line or it obtains the four parameters
-from respective environment variables.
+The ``ttnlogger`` program can be invoked in two ways. Either it obtains the TTN
+credentials as two positional arguments on the command line or it obtains the two
+parameters from respective environment variables.
 
+The InfluxDB agent database as well as the measurement are being derived from
+the TTN ``dev_id``. In case of using it within the Hiveeyes.org environment
+please follow this ``dev_id`` scheme:
+
+``hiveeyes-USER-LOCATION-NAMEOFHIVE``
+
+and replace upper case strings with your individual lower case namings without additional dashes)
 
 Command line arguments
 ----------------------
 ::
 
-    ttnlogger "<ttn_app_id>" "<ttn_access_key>" "<influxdb_database>" "<influxdb_measurement>"
+    ttnlogger "<ttn_app_id>" "<ttn_access_key>"
 
 
 Environment variables
@@ -32,8 +39,6 @@ Environment variables
 
     export TTN_APP_ID="testdrive"
     export TTN_ACCESS_KEY="ttn-account-v2.UcOZ3_gRRVbzsJ1lR7WfuINLN_DKIlc9oKvgukHPGck"
-    export INFLUXDB_DATABASE="test"
-    export INFLUXDB_MEASUREMENT="data"
 
     ttnlogger
 

--- a/README.rst
+++ b/README.rst
@@ -15,12 +15,12 @@ TTN (`The Things Network`_) is building a global open LoRaWAN™ network.
 Synopsis
 ********
 The ``ttnlogger`` program can be invoked in two ways. Either it obtains the TTN
-credentials as two positional arguments on the command line or it obtains the two
-parameters from respective environment variables.
+credentials as well as InfluxDB database and measurement as four command-line options
+or it obtains the parameters from respective environment variables.
 
-The InfluxDB agent database as well as the measurement are being derived from
-the TTN ``dev_id``. In case of using it within the Hiveeyes.org environment
-please follow this ``dev_id`` scheme:
+With the ``-s`` option the InfluxDB agent database as well as the measurement are being
+derived from the TTN ``dev_id`` while ``-d`` and ``-m`` are being ignored.
+In case of using it within the Hiveeyes.org environment please follow this scheme for the ``dev_id``:
 
 ``hiveeyes-USER-LOCATION-NAMEOFHIVE``
 
@@ -30,7 +30,7 @@ Command line arguments
 ----------------------
 ::
 
-    ttnlogger "<ttn_app_id>" "<ttn_access_key>"
+    ttnlogger -i "<ttn_app_id>" -k "<ttn_access_key>" [-s] [-d <influxdb_database>] [-m <influxdb_measurement>]
 
 
 Environment variables
@@ -39,7 +39,8 @@ Environment variables
 
     export TTN_APP_ID="testdrive"
     export TTN_ACCESS_KEY="ttn-account-v2.UcOZ3_gRRVbzsJ1lR7WfuINLN_DKIlc9oKvgukHPGck"
-
+    export INFLUXDB_DATABASE="test"
+    export INFLUXDB_MEASUREMENT="data"
     ttnlogger
 
 
@@ -54,7 +55,7 @@ Setup
     python setup.py develop
 
 
-Run as systemd unit::
+Run as systemd unit ()::
 
     cp etc/default/ttnlogger /etc/default/
     ln -sr etc/systemd/ttnlogger.service /usr/lib/systemd/system/

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras = {
 }
 
 setup(name='ttnlogger',
-      version='0.1.0',
+      version='0.2.0',
       description='Converge TTN messages into InfluxDB and MongoDB and display in Grafana',
       long_description=README,
       license="AGPL 3, EUPL 1.2",

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -25,8 +25,8 @@ class TTNDatenpumpe:
         influxdb_database = '_'.join(influxdb_env[:2])
         influxdb_measurement = '_'.join(influxdb_env[2:])
 
-        #print('influxdb_database    :', influxdb_database)
-        #print('influxdb_measurement :', influxdb_measurement)
+        print('influxdb_database     :', influxdb_database)
+        print('influxdb_measurement  :', influxdb_measurement)
 
         self.influxdb = InfluxDatabase(database=influxdb_database, measurement=influxdb_measurement)
 
@@ -36,7 +36,6 @@ class TTNDatenpumpe:
             print('ERROR:', ex)
 
         try:
-            self.influxdb.close()
             del self.influxdb
         except Exception as ex:
             print('ERROR: Could not delete InfluxDB object', ex)

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -135,6 +135,7 @@ class InfluxDatabase:
 
             # gateway location
             if not self.nogeo:
+                key_lat  = 'gw_' + gtw_id + '_lat'
                 key_lon  = 'gw_' + gtw_id + '_lon'
                 key_alt  = 'gw_' + gtw_id + '_alt'
                 data[key_lat] = float(ttn_message.metadata.gateways[i].latitude)

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -177,11 +177,11 @@ def run():
         parser.error('Missing -s requires --database and --measurement options. See -h for help.')
         sys.exit(1)
 
+    ttn = TTNClient(ttn_app_id, ttn_access_key)
+
     if options.split is True:
-        ttn = TTNClient(ttn_app_id, ttn_access_key)
         datenpumpe = TTNDatenpumpe(ttn)
     else:
-        ttn = TTNClient(ttn_app_id, ttn_access_key)
         influxdb = InfluxDatabase(database=influxdb_database, measurement=influxdb_measurement)
         datenpumpe = TTNDatenpumpe(ttn, influxdb)
 

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -121,8 +121,8 @@ class InfluxDatabase:
         for i in range(num_gtws):
             gtw_id = ttn_message.metadata.gateways[i].gtw_id
             print('Gateway ' + str(i+1) + ' ID          : ' + gtw_id)
-            key_rssi = 'rssi_' + gtw_id
-            key_snr  = 'snr_' + gtw_id
+            key_rssi = 'gw_' + gtw_id + '_rssi'
+            key_snr  = 'gw_' + gtw_id + '_snr'
             data[key_rssi] = int(ttn_message.metadata.gateways[i].rssi)
             data[key_snr] = float(ttn_message.metadata.gateways[i].snr)
 

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -154,8 +154,8 @@ class InfluxDatabase:
 
 def run():
     parser = argparse.ArgumentParser(description='Subscribe to TTN MQTT topic and write data to InfluxDB')
-    parser.add_argument('-i', '--ttn_app_id', dest='ttn_app_id', action='store')
-    parser.add_argument('-k', '--ttn_access_key', dest='ttn_access_key', action='store')
+    parser.add_argument('-i', '--ttn_app_id', dest='ttn_app_id', action='store', required=True)
+    parser.add_argument('-k', '--ttn_access_key', dest='ttn_access_key', action='store', required=True)
     parser.add_argument('-s', '--split-topic', dest='split', action='store_true', default=False, help='Get InfluxDB database and measurement from MQTT topic split. If not set provide with --database and --measurement')
     parser.add_argument('-d', '--database', dest='influxdb_database', action='store', help='InfluxDB database')
     parser.add_argument('-m', '--measurement', dest='influxdb_measurement', action='store', help='InfluxDB measurement')

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -28,17 +28,18 @@ class TTNDatenpumpe:
         #print('influxdb_database    :', influxdb_database)
         #print('influxdb_measurement :', influxdb_measurement)
 
-        try:
-            del self.influxdb
-        except Exception as ex:
-            print('ERROR: Could not delete InfluxDB object', ex)
-
         self.influxdb = InfluxDatabase(database=influxdb_database, measurement=influxdb_measurement)
 
         try:
             self.influxdb.store(message)
         except Exception as ex:
             print('ERROR:', ex)
+
+        try:
+            self.influxdb.close()
+            del self.influxdb
+        except Exception as ex:
+            print('ERROR: Could not delete InfluxDB object', ex)
 
     def enable(self):
         self.ttn.receive_callback = self.on_receive

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -21,7 +21,7 @@ class TTNDatenpumpe:
     def on_receive(self, message=None, client=None):
         #print('on_receive:', message, client)
 
-        influxdb_env = message.dev_id.replace("-", "_").split("_")
+        influxdb_env = message.dev_id.split('-')
         influxdb_database = '_'.join(influxdb_env[:2])
         influxdb_measurement = '_'.join(influxdb_env[2:])
 

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -126,10 +126,13 @@ class InfluxDatabase:
             data[key_rssi] = int(ttn_message.metadata.gateways[i].rssi)
             data[key_snr] = float(ttn_message.metadata.gateways[i].snr)
 
+        data['sf'] = int(ttn_message.metadata.data_rate.split('BW')[0][2:])
+        data['bw'] = int(ttn_message.metadata.data_rate.split('BW')[1])
+
         data['gtw_count'] = int(num_gtws)
 
         # Convert all numeric values to floats.
-        data = convert_floats(data, integers="gtw_count")
+        data = convert_floats(data, integers="gtw_count,sf,bw")
 
         # Add application and device id as tags.
         tags = OrderedDict()

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -132,7 +132,7 @@ class InfluxDatabase:
         data['gtw_count'] = int(num_gtws)
 
         # Convert all numeric values to floats.
-        data = convert_floats(data, integers="gtw_count,sf,bw")
+        data = convert_floats(data, integers=["gtw_count", "sf", "bw"])
 
         # Add application and device id as tags.
         tags = OrderedDict()

--- a/ttnlogger/ttn_logger.py
+++ b/ttnlogger/ttn_logger.py
@@ -116,15 +116,21 @@ class InfluxDatabase:
             data[field] = value
 
         # Pick up telemetry values from gateway information.
-        gw0 = ttn_message.metadata.gateways[0]
-        data['gw_rssi'] = float(gw0.rssi)
-        data['gw_snr'] = float(gw0.snr)
-        data['gw_latitude'] = float(gw0.latitude)
-        data['gw_longitude'] = float(gw0.longitude)
-        data['gw_altitude'] = float(gw0.altitude)
+        num_gtws = len(ttn_message.metadata.gateways)
+        print('Message received from ' + str(num_gtws) + ' gateway(s)')
+
+        for i in range(num_gtws):
+            gtw_id = ttn_message.metadata.gateways[i].gtw_id
+            print('Gateway ' + str(i+1) + ' ID          : ' + gtw_id)
+            key_rssi = 'rssi_' + gtw_id
+            key_snr  = 'snr_' + gtw_id
+            data[key_rssi] = int(ttn_message.metadata.gateways[i].rssi)
+            data[key_snr] = float(ttn_message.metadata.gateways[i].snr)
+
+        data['gtw_count'] = int(num_gtws)
 
         # Convert all numeric values to floats.
-        data = convert_floats(data)
+        data = convert_floats(data, integers="gtw_count")
 
         # Add application and device id as tags.
         tags = OrderedDict()

--- a/ttnlogger/util.py
+++ b/ttnlogger/util.py
@@ -11,7 +11,7 @@ def convert_floats(data, integers=None):
     """
     integers = integers or []
     delete_keys = []
-    for key, value in data.iteritems():
+    for key, value in data.items():
         try:
             if isinstance(value, datetime.datetime):
                 continue


### PR DESCRIPTION
- fix for ERROR: 'collections.OrderedDict' object has no attribute 'iteritems'
- optional: dynamic InfluxDB database and measurement derived from `dev_id`, e.g. when more than one device registered in TTN App
- store LoRa signal quality data from all receiving gateways